### PR TITLE
Removing upper bounds on base dependencies

### DIFF
--- a/dwergaz.cabal
+++ b/dwergaz.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dwergaz
-version:             0.2.0.1
+version:             0.2.0.2
 synopsis:            A minimal testing library
 description:         A minimal testing library
 license:             BSD3
@@ -30,7 +30,7 @@ library
   exposed-modules:     Test.Dwergaz
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.11
+  build-depends:       base >=4.8 && <4.12
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -38,7 +38,7 @@ library
 test-suite tests
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
-  build-depends:       base >=4.8 && <4.11
+  build-depends:       base >=4.8 && <4.12
                      , dwergaz
   hs-source-dirs:      tests
   default-language:    Haskell2010


### PR DESCRIPTION
Currently having trouble using `dwergaz` and `haskell.compiler.ghc.841` in nix.

Removing upper bound on base seems to resolve the issue.